### PR TITLE
Add method to retrieve the applicable public suffix even for exact matches

### DIFF
--- a/lib/tld.js
+++ b/lib/tld.js
@@ -147,7 +147,7 @@ tld.prototype.tldExists = function tldExists(host){
  * @return {String}
  */
 tld.prototype.getPublicSuffix = function getPublicSuffix(host) {
-  if (this.rules[host](host)){
+  if (this.rules[host]){
 	  return host;
   }
   


### PR DESCRIPTION
publicsuffix.org's purpose is cookie security; as such, looking up the public suffix
of a direct public suffix is defined to return null (e.g. 's3.amazonaws.com')
for my use, I want only to know the VALUE of the public suffix, so null is bad
I added a method, .getPublicSuffix, which will compensate for this
