### PR TITLE
Make rules with no exceptions valid

### DIFF
--- a/lib/tld.js
+++ b/lib/tld.js
@@ -141,7 +141,7 @@ tld.prototype.getRulesForTld = function getRulesForTld (tld, default_rule) {
   }
 
   // Nothing found, apply some default value
-  if (!rules) {
+  if (rules === void 0) {
     return default_rule ? [ default_rule ] : [];
   }
 

--- a/test/tld.js
+++ b/test/tld.js
@@ -127,6 +127,11 @@ describe('tld.js', function () {
       expect(tld.getPublicSuffix('youtube')).to.be('youtube');
     });
 
+    it('should return the suffix if a rule exists that has no exceptions', function(){
+      expect(tld.rules.eu).to.be('');
+      expect(tld.getPublicSuffix('microsoft.eu')).to.be('eu');
+    });
+
     it('should return null if the publicsuffix does not exist', function(){
       expect(tld.getPublicSuffix('www.freedom.nsa')).to.be(null);
     });


### PR DESCRIPTION
Fixes a problem where suffixes that are valid (like .fm and .eu) but were falling to parse correctly:

```
tldjs.rules.eu // returns ""
tldjs.getPublicSuffix('microsoft.eu') // expect `microsoft', get null
```