### PR TITLE
Build against all major nodejs and iojs versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: "node_js"
-node_js: "0.10"
+
+node_js:
+    - "0.10"
+    - "0.12"
+    - "iojs-1"
+    - "iojs-2"
+    - "iojs-3"
 
 sudo: false
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "tld",
   "main": "index.js",
-  "version": "1.5.1",
+  "version": "1.5.3",
   "homepage": "https://github.com/oncletom/tld.js",
   "authors": [
     "Thomas Parisot (https://oncletom.io)"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/oncletom/tld.js/issues"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": ">= 0.10"
   },
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Hi,

I just updated Travis CI build matrix and package.json to avoid unproper warning with recent `nodejs` versions.