### PR TITLE
Add a benchmark script to tld.js to measure performance evolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ node_js:
 - v6
 - node
 
+cache:
+  directories:
+  - node_modules
+
 notifications:
   email:
     on_failure: change
@@ -25,6 +29,6 @@ deploy:
     secure: D+AvrtOi8eox2H+j6T1EmaRrFThTDRlfRDQjDdCs7D1WnPoSs0wMcnd0lVi0lEj68URkm/4fDmHVtLXt1V8BLyfHwt3bZUsF1pe77qUTZZkmfDI5TRxp/mni6TrpFTlYaqytyunPKm19FciWj/IE2epVhWmJ8kQx/oB/lSq9SFo=
   on:
     tags: true
-    node: v6
+    node: node
     branch: master
     repo: oncletom/tld.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ install: npm install --tldjs-update-rules
 
 script: xvfb-run -a npm test
 
+post_script: npm run benchmark
+
 deploy:
   provider: npm
   email: hi@oncletom.io

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,13 @@
-Copyright (c) 2013 Thomas Parisot
+Copyright (c) 2017 Thomas Parisot
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to deal in the Software without restriction, 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
 including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,7 @@
 
 It answers with accuracy to questions like _what is `mail.google.com` domain?_,  _what is `a.b.ide.kyoto.jp` subdomain?_ and _is `https://big.data` TLD a well-known one?_.
 
-`tld.js` runs fast and is fully tested, works both in Node.js and in the browser. Because it relies on Mozilla's [public suffix list][], now is a good time to say _thank you_ Mozilla!
-
-```
-tldjs#tldExists x 326,500 ops/sec ±0.83% (92 runs sampled)
-tldjs#getDomain x 203,000 ops/sec ±3.08% (84 runs sampled)
-tldjs#getSubdomain x 203,700 ops/sec ±2.85% (85 runs sampled)
-tldjs#getPublicSuffix x 219,500 ops/sec ±3.53% (83 runs sampled)
-```
+`tld.js` [runs fast](#performances), is fully tested and works both in Node.js and in the browser. Because it relies on Mozilla's [public suffix list][], now is a good time to say _thank you_ Mozilla!
 
 # Install
 
@@ -200,6 +193,28 @@ Open an issue to request an update of the bundled TLDs.
 
 Provide a pull request (with tested code) to include your work in this main project.
 Issues may be awaiting for help so feel free to give a hand, with code or ideas.
+
+# Performances
+
+```
+While interpreting the results, keep in mind that each "op" reported by the benchmark is processing 24 domains
+tldjs#isValid x 1,952,688 ops/sec ±1.27% (86 runs sampled)
+tldjs#cleanHost x 11,901 ops/sec ±1.53% (84 runs sampled)
+tldjs#tldExists x 10,030 ops/sec ±2.20% (83 runs sampled)
+tldjs#getDomain x 3,705 ops/sec ±4.86% (71 runs sampled)
+tldjs#getSubdomain x 3,035 ops/sec ±1.58% (81 runs sampled)
+tldjs#getPublicSuffix x 7,038 ops/sec ±1.88% (83 runs sampled)
+```
+
+You can measure the performance of `tld.js` on your hardware by running the following command:
+
+```bash
+npx tldjs -c './bin/benchmark.js'
+```
+
+# License
+
+[MIT License](LICENSE).
 
 [badge-ci]: https://secure.travis-ci.org/oncletom/tld.js.svg?branch=master
 [badge-downloads]: https://img.shields.io/npm/dm/tldjs.svg

--- a/bin/benchmark.js
+++ b/bin/benchmark.js
@@ -1,0 +1,96 @@
+
+var tld = require('../index.js');
+var Benchmark = require('benchmark');
+
+
+var DOMAINS = [
+  // No public suffix
+  'example.foo.edu.au', // null
+  'example.foo.edu.sh', // null
+  'example.disrec.thingdust.io', // null
+  'foo.bar.baz.ortsinfo.at', // null
+
+  // ICANN
+  'example.foo.nom.br', // *.nom.br
+  'example.wa.edu.au', // wa.edu.au
+  'example.com', // com
+  'example.co.uk', // co.uk
+
+  // Private
+  'foo.bar.baz.stolos.io', // *.stolos.io
+  'foo.art.pl', // art.pl
+  'foo.privatizehealthinsurance.net', // privatizehealthinsurance.net
+  'example.cust.disrec.thingdust.io', // cust.disrec.thingdust.io
+
+  // Exception
+  'foo.city.kitakyushu.jp', // !city.kitakyushu.jp
+  'example.www.ck', // !www.ck
+  'foo.bar.baz.city.yokohama.jp', // !city.yokohama.jp
+  'example.city.kobe.jp', // !city.kobe.jp
+
+  // IDN labels
+  'example.北海道.jp', // 北海道.jp
+  'example.和歌山.jp', // 和歌山.jp
+  'foo.bar.baz.ايران.ir', // ايران.ir
+  'foo.bar.baz.موبايلي', // موبايلي
+
+  // Mixed case
+  'ExAmPlE.北海道.JP', // 北海道.jp
+  'example.Cust.Disrec.Thingdust.Io', // cust.disrec.thingdust.io
+  'Example.Wa.Edu.Au', // wa.edu.au
+  'FOO.bar.BAZ.ortsinfo.AT', // null
+
+  // Full URLs
+  // '2001:0DB8:0100:F101:0210:A4FF:FEE3:9566',
+  // 'http://user:pass@www.examplegoogle.com:21/blah#baz',
+  // 'http://iris.test.ing/&#x1E0B;&#x0323;/?&#x1E0B;&#x0323;#&#x1E0B;&#x0323;',
+  // 'http://0000000000000300.0xffffffffFFFFFFFF.3022415481470977',
+];
+
+
+// TODO - Compare to other libraries
+function main() {
+  console.log(
+    'While interpreting the results, keep in mind that each "op" reported' +
+    ' by the benchmark is processing ' + DOMAINS.length + ' domains'
+  );
+
+  new Benchmark.Suite()
+    .add('tldjs#isValid', () => {
+      for (var i = 0; i < DOMAINS.length; i += 1) {
+        tld.isValid(DOMAINS[i]);
+      }
+    })
+    .add('tldjs#cleanHost', () => {
+      for (var i = 0; i < DOMAINS.length; i += 1) {
+        tld.cleanHostValue(DOMAINS[i]);
+      }
+    })
+    .add('tldjs#tldExists', () => {
+      for (var i = 0; i < DOMAINS.length; i += 1) {
+        tld.tldExists(DOMAINS[i]);
+      }
+    })
+    .add('tldjs#getDomain', () => {
+      for (var i = 0; i < DOMAINS.length; i += 1) {
+        tld.getDomain(DOMAINS[i]);
+      }
+    })
+    .add('tldjs#getSubdomain', () => {
+      for (var i = 0; i < DOMAINS.length; i += 1) {
+        tld.getSubdomain(DOMAINS[i]);
+      }
+    })
+    .add('tldjs#getPublicSuffix', () => {
+      for (var i = 0; i < DOMAINS.length; i += 1) {
+        tld.getPublicSuffix(DOMAINS[i]);
+      }
+    })
+    .on('cycle', function (event) {
+      console.log(String(event.target));
+    })
+    .run();
+}
+
+
+main();

--- a/bin/benchmark.js
+++ b/bin/benchmark.js
@@ -1,3 +1,6 @@
+#!/usr/bin/env node
+
+'use strict';
 
 var tld = require('../index.js');
 var Benchmark = require('benchmark');

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,24 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4",
+        "platform": "1.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
     "bl": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
@@ -3840,6 +3858,12 @@
       "requires": {
         "pinkie": "2.0.4"
       }
+    },
+    "platform": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
+      "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
+      "dev": true
     },
     "plist": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -17,15 +17,16 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "lint": "jshint --config .jshintrc lib/**/*.js",
-    "test": "nyc mocha -R dot -r env-test",
-    "posttest": "npm run lint && npm run test-browser",
-    "test-watch": "mocha -R dot -r env-test --watch",
-    "test-browser": "testling",
-    "update": "node ./bin/update.js",
-    "postinstall": "node ./bin/postinstall.js",
+    "benchmark": "node ./bin/benchmark.js",
     "generate-changelog": "github-changes -o oncletom -r 'tld.js' -n ${npm_package_version} --only-pulls --use-commit-body",
+    "lint": "jshint --config .jshintrc lib/**/*.js",
+    "postinstall": "node ./bin/postinstall.js",
+    "posttest": "npm run lint && npm run test-browser",
     "prepublish": "npm run update",
+    "test": "nyc mocha -R dot -r env-test",
+    "test-browser": "testling",
+    "test-watch": "mocha -R dot -r env-test --watch",
+    "update": "node ./bin/update.js",
     "version": "npm run generate-changelog && git add CHANGELOG.md"
   },
   "tldjs": {
@@ -57,6 +58,7 @@
     "punycode": "^1.4.1"
   },
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "env-test": "^1.0.0",
     "expect.js": "^0.3.1",
     "github-changes": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/oncletom/tld.js/issues"
   },
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 4"
   },
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This PR adds a `bin/benchmark` script, measuring all functions part of the public API. I tried to design the set of URLs tested during the benchmark to be representative, and diverse enough to hit different corner cases (`*` rules, ICANN rules, Private rules, exceptions, unicode, etc.).