### PR TITLE
Implement a more strict hostname validation (isValid)

### DIFF
--- a/lib/is-valid.js
+++ b/lib/is-valid.js
@@ -1,15 +1,124 @@
 "use strict";
 
+
 /**
- * Checking if a host string is valid
+ * Check if the code point is a digit [0-9]
+ *
+ * @param {number} code
+ * @return boolean
+ */
+function isDigit(code) {
+  // 48 == '0'
+  // 57 == '9'
+  return code >= 48 && code <= 57;
+}
+
+
+/**
+ * Check if the code point is a letter [a-zA-Z]
+ *
+ * @param {number} code
+ * @return boolean
+ */
+function isAlpha(code) {
+  // Force to lower-case
+  code |= 32;
+  // 97 === 'a'
+  // 122 == 'z'
+  return code >= 97 && code <= 122;
+}
+
+
+/**
+ * Check if the code point is a valid character in first position of a hostname.
+ *
+ * @param {number} code
+ * @return boolean
+ */
+function isAllowedFirstHostnameChar(code) {
+  return isAlpha(code) || isDigit(code);
+}
+
+
+/**
+ * Check if the code point is a valid hostname character.
+ *
+ * @param {number} code
+ * @return boolean
+ */
+function isAllowedHostnameChar(code) {
+  return (
+    isAlpha(code) ||
+    isDigit(code) ||
+    code === 45 // '-'
+  );
+}
+
+
+/**
+ * Check if a host string is valid (according to RFC
  * It's usually a preliminary check before trying to use getDomain or anything else
  *
  * Beware: it does not check if the TLD exists.
  *
  * @api
- * @param host {String}
- * @return {Boolean}
+ * @param {string} host
+ * @return {boolean}
  */
 module.exports = function isValid(validHosts, host) {
-  return typeof host === 'string' && (validHosts.indexOf(host) !== -1 || (host.indexOf('.') !== -1 && host[0] !== '.'));
+  if (typeof host !== 'string') {
+    return false;
+  }
+
+  if (host.length > 255) {
+    return false;
+  }
+
+  if (validHosts.indexOf(host) !== -1) {
+    return true;
+  }
+
+  if (host.length === 0) {
+    return false;
+  }
+
+  // Check first character
+  if (isAllowedFirstHostnameChar(host.charCodeAt(0)) === false) {
+    return false;
+  }
+
+  // Validate host according to RFC
+  var lastDotIndex = -1;
+  var i = 0;
+  for (; i < host.length; i += 1) {
+    var code = host.charCodeAt(i);
+
+    if (code === 46) { // '.'
+      // Check maximum label size is 63 octets
+      if ((i - lastDotIndex) > 64) {
+        return false;
+      }
+
+      // Forbid two consecutive dots
+      if (lastDotIndex === (i - 1)) {
+        return false;
+      }
+
+      lastDotIndex = i;
+    } else if (isAllowedHostnameChar(code) === false) {
+      return false;
+    }
+  }
+
+  // Check that hostname contains at least one dot.
+  if (lastDotIndex === -1) {
+    return false;
+  }
+
+  // Check that last label is <= 63 octets long
+  if ((i - lastDotIndex) > 64) {
+    return false;
+  }
+
+  return true;
 };

--- a/lib/is-valid.js
+++ b/lib/is-valid.js
@@ -22,36 +22,10 @@ function isDigit(code) {
  */
 function isAlpha(code) {
   // Force to lower-case
-  code |= 32;
+  // code |= 32;
   // 97 === 'a'
   // 122 == 'z'
-  return code >= 97 && code <= 122;
-}
-
-
-/**
- * Check if the code point is a valid character in first position of a hostname.
- *
- * @param {number} code
- * @return boolean
- */
-function isAllowedFirstHostnameChar(code) {
-  return isAlpha(code) || isDigit(code);
-}
-
-
-/**
- * Check if the code point is a valid hostname character.
- *
- * @param {number} code
- * @return boolean
- */
-function isAllowedHostnameChar(code) {
-  return (
-    isAlpha(code) ||
-    isDigit(code) ||
-    code === 45 // '-'
-  );
+  return (code | 32) >= 97 && (code | 32) <= 122;
 }
 
 
@@ -82,43 +56,53 @@ module.exports = function isValid(validHosts, host) {
     return false;
   }
 
-  // Check first character
-  if (isAllowedFirstHostnameChar(host.charCodeAt(0)) === false) {
+  // Check first character: [a-zA-Z0-9]
+  var firstCharCode = host.charCodeAt(0);
+  if (!(isAlpha(firstCharCode) || isDigit(firstCharCode))) {
     return false;
   }
 
   // Validate host according to RFC
   var lastDotIndex = -1;
-  var i = 0;
-  for (; i < host.length; i += 1) {
-    var code = host.charCodeAt(i);
+  var lastCharCode;
+  var code;
+  var len = host.length;
+
+  for (var i = 0; i < len; i += 1) {
+    code = host.charCodeAt(i);
 
     if (code === 46) { // '.'
-      // Check maximum label size is 63 octets
-      if ((i - lastDotIndex) > 64) {
-        return false;
-      }
-
-      // Forbid two consecutive dots
-      if (lastDotIndex === (i - 1)) {
+      if (
+        // Check that previous label is < 63 bytes long (64 = 63 + '.')
+        (i - lastDotIndex) > 64 ||
+        // Check that previous character was not already a '.'
+        lastCharCode === 46 ||
+        // Check that the previous label does not end with a '-'
+        lastCharCode === 45
+      ) {
         return false;
       }
 
       lastDotIndex = i;
-    } else if (isAllowedHostnameChar(code) === false) {
+    } else if (!(isAlpha(code) || isDigit(code) || code === 45)) {
+      // Check if there is a forbidden character in the label: [^a-zA-Z0-9-]
       return false;
     }
+
+    lastCharCode = code;
   }
 
-  // Check that hostname contains at least one dot.
+  // We expect at least one dot in hostname
   if (lastDotIndex === -1) {
     return false;
   }
 
-  // Check that last label is <= 63 octets long
-  if ((i - lastDotIndex) > 64) {
-    return false;
-  }
-
-  return true;
+  return (
+    // Check that last label is shorter than 63 chars
+    (len - lastDotIndex - 1) <= 63 &&
+    // Check that the last character is an allowed trailing label character.
+    // Since we already checked that the char is a valid hostname character,
+    // we only need to check that it's different from '-'.
+    lastCharCode !== 45
+  );
 };

--- a/test/tld.js
+++ b/test/tld.js
@@ -29,15 +29,37 @@ describe('tld.js', function () {
   });
 
   describe('isValid method', function () {
+    // That's a 255 characters long hostname
+    var maxSizeHostname = 'a';
+    for (var i = 0; i < 127; i += 1) {
+      maxSizeHostname += '.a';
+    }
+
     it('should detect valid hostname', function () {
       expect(tld.isValid('')).to.be(false);
       expect(tld.isValid('localhost')).to.be(false);
+      expect(tld.isValid('-google.com')).to.be(false);
+      expect(tld.isValid('.google.com')).to.be(false);
+      expect(tld.isValid('google..com')).to.be(false);
+      expect(tld.isValid('google.com..')).to.be(false);
+      expect(tld.isValid('example.' + 'a'.repeat(64) + '.')).to.be(false);
+      expect(tld.isValid('example.' + 'a'.repeat(64))).to.be(false);
+      expect(tld.isValid('googl@.com..')).to.be(false);
+
       expect(tld.isValid('google.com')).to.be(true);
       expect(tld.isValid('miam.google.com')).to.be(true);
       expect(tld.isValid('miam.miam.google.com')).to.be(true);
+      expect(tld.isValid('example.' + 'a'.repeat(63) + '.')).to.be(true);
+      expect(tld.isValid('example.' + 'a'.repeat(63))).to.be(true);
 
       //@see https://github.com/oncletom/tld.js/issues/95
       expect(tld.isValid('miam.miam.google.com.')).to.be(true);
+
+      // Length of 255 (maximum allowed)
+      expect(tld.isValid(maxSizeHostname)).to.be(true);
+
+      // Length of 256 (too long)
+      expect(tld.isValid(maxSizeHostname + 'a')).to.be(false);
     });
 
     it('should detect invalid hostname', function () {

--- a/test/tld.js
+++ b/test/tld.js
@@ -39,12 +39,17 @@ describe('tld.js', function () {
       expect(tld.isValid('')).to.be(false);
       expect(tld.isValid('localhost')).to.be(false);
       expect(tld.isValid('-google.com')).to.be(false);
+      expect(tld.isValid('google-.com')).to.be(false);
+      expect(tld.isValid('google.com-')).to.be(false);
       expect(tld.isValid('.google.com')).to.be(false);
       expect(tld.isValid('google..com')).to.be(false);
       expect(tld.isValid('google.com..')).to.be(false);
       expect(tld.isValid('example.' + 'a'.repeat(64) + '.')).to.be(false);
       expect(tld.isValid('example.' + 'a'.repeat(64))).to.be(false);
       expect(tld.isValid('googl@.com..')).to.be(false);
+
+      // Length of 256 (too long)
+      expect(tld.isValid(maxSizeHostname + 'a')).to.be(false);
 
       expect(tld.isValid('google.com')).to.be(true);
       expect(tld.isValid('miam.google.com')).to.be(true);
@@ -57,9 +62,6 @@ describe('tld.js', function () {
 
       // Length of 255 (maximum allowed)
       expect(tld.isValid(maxSizeHostname)).to.be(true);
-
-      // Length of 256 (too long)
-      expect(tld.isValid(maxSizeHostname + 'a')).to.be(false);
     });
 
     it('should detect invalid hostname', function () {


### PR DESCRIPTION
Attempt at addressing #59 and #73 (it should be trivial to allow `_` as well, but we should probably discuss of a possible API for that there => #99).

This function implements a more strict validation of the hostnames. It checks:

- maximum total size (255)
- maximum size of a label (63)
- allowed characters: [0-9a-zA-Z] for first character and [0-9a-zA-Z-] for the rest
- Forbid two consecutive dots

As far as I know that should be it, but let me know if you see some corner cases that are not covered.

Regarding performance, this one times at:
```
tldjs#isValid x 8,112,000 ops/sec ±0.26% (96 runs sampled)
```

This is about `x6` slower than the previous implementation (which did not check much). So I'd say it's still fast enough (compared to `cleanHost` ~ `360,000 ops/sec` or `getDomain` ~ `120,000 ops/sec`). I also compared it with a more naive validation regex (which does not check every thing) which times at `9,574,128 ops/sec`.[1]

---

[1] `/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/` (does not check maximum size, maximum label size, forbid trailing dot).