### PR TITLE
If protocol is missing, add it explicitely

### DIFF
--- a/lib/clean-host.js
+++ b/lib/clean-host.js
@@ -26,7 +26,7 @@ function rtrim(value) {
 module.exports = function cleanHostValue(value) {
   value = String(value).trim().toLowerCase();
 
-  var parts = URL.parse(hasPrefixRE.test(value) ? value : '//' + value, null, true);
+  var parts = URL.parse(hasPrefixRE.test(value) ? value : 'http://' + value, null, true);
 
   if (parts.hostname && !invalidHostnameChars.test(parts.hostname)) {
     return rtrim(parts.hostname);


### PR DESCRIPTION
Node URL parser behaviour differs if protocol is missing.

```
require('url').parse('//sh/a.aspx')
Url {
  protocol: null,
  slashes: null,
  auth: null,
  host: null,
  port: null,
  hostname: null,
  hash: null,
  search: null,
  query: null,
  pathname: '//sh/a.aspx',
  path: '//sh/a.aspx',
  href: '//sh/a.aspx' }
```

vs 

```
require('url').parse('http://sh/a.aspx')
Url {
  protocol: 'http:',
  slashes: true,
  auth: null,
  host: 'sh',
  port: null,
  hostname: 'sh',
  hash: null,
  search: null,
  query: null,
  pathname: '/a.aspx',
  path: '/a.aspx',
  href: 'http://sh/a.aspx' }
```

fixes #106