### PR TITLE
Add ip validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > `tld.js` is a Node.js module written in JavaScript to work against complex domain names, subdomains and well-known TLDs.
 
-It answers with accuracy to questions like _what is `mail.google.com` domain?_,  _what is `a.b.ide.kyoto.jp` subdomain?_ and _is `https://big.data` TLD a well-known one?_.
+It answers with accuracy to questions like _what is `mail.google.com`'s domain?_,  _what is `a.b.ide.kyoto.jp`'s subdomain?_ and _is `https://big.data`'s TLD a well-known one?_.
 
 `tld.js` [runs fast](#performances), is fully tested and is safe to use in the browser (with [browserify][], webpack and others). Because it relies on Mozilla's [public suffix list][], now is a good time to say _thank you_ Mozilla!
 
@@ -43,23 +43,33 @@ This methods returns handy **properties about a URL or a hostname**.
 const tldjs = require('tldjs');
 
 tldjs.parse('https://spark-public.s3.amazonaws.com/dataanalysis/loansData.csv');
-// {
-//   "hostname": "spark-public.s3.amazonaws.com",
-//   "isValid": true,
-//   "tldExists": true,
-//   "publicSuffix": "s3.amazonaws.com",
-//   "domain": "spark-public.s3.amazonaws.com",
-//   "subdomain": ""
+// { hostname: 'spark-public.s3.amazonaws.com',
+//   isValid: true,
+//   isIp: false,
+//   tldExists: true,
+//   publicSuffix: 's3.amazonaws.com',
+//   domain: 'spark-public.s3.amazonaws.com',
+//   subdomain: ''
 // }
 
 tldjs.parse('gopher://domain.unknown/');
-// {
-//   "hostname": "domain.unknown",
-//   "isValid": true,
-//   "tldExists": false,
-//   "publicSuffix": "unknown",
-//   "domain": "domain.unknown",
-//   "subdomain": ""
+// { hostname: 'domain.unknown',
+//   isValid: true,
+//   isIp: false,
+//   tldExists: false,
+//   publicSuffix: 'unknown',
+//   domain: 'domain.unknown',
+//   subdomain: ''
+// }
+
+tldjs.parse('https://192.168.0.0')
+// { hostname: '192.168.0.0',
+//   isValid: true,
+//   isIp: true,
+//   tldExists: false,
+//   publicSuffix: null,
+//   domain: null,
+//   subdomain: null
 // }
 ```
 
@@ -154,6 +164,7 @@ isValid('.google.com');     // returns `false`
 isValid('my.fake.domain');  // returns `true`
 isValid('localhost');       // returns `false`
 isValid('https://user:password@example.co.uk:8080/some/path?and&query#hash'); // returns `true`
+isValid('192.168.0.0')      // returns `true`
 ```
 
 # Troubleshooting
@@ -209,22 +220,48 @@ Issues may be awaiting for help so feel free to give a hand, with code or ideas.
 
 # Performances
 
-```
-While interpreting the results, keep in mind that each "op" reported by the benchmark is processing 24 domains
-tldjs#isValid x 230,353 ops/sec ±10.99% (44 runs sampled)
-tldjs#extractHostname x 42,333 ops/sec ±2.82% (85 runs sampled)
-tldjs#tldExists x 15,083 ops/sec ±8.76% (54 runs sampled)
-tldjs#getPublicSuffix x 14,334 ops/sec ±8.00% (80 runs sampled)
-tldjs#getDomain x 15,092 ops/sec ±1.92% (84 runs sampled)
-tldjs#getSubdomain x 13,202 ops/sec ±3.66% (72 runs sampled)
-tldjs#parse x 8,561 ops/sec ±11.78% (55 runs sampled)
-```
+`tld.js` is fast, but keep in mind that it might vary depending on your own
+use-case. Because the library tried to be smart, the speed can be drastically
+different depending on the input (it will be faster if you provide an already
+cleaned hostname, compared to a random URL).
+
+On an Intel i7-6600U (2,60-3,40 GHz):
+
+## For already cleaned hostnames
+
+| Methods           | ops/sec      |
+| ---               | ---          |
+| `isValid`         | ~`8,700,000` |
+| `extractHostname` | ~`8,100,000` |
+| `tldExists`       | ~`2,000,000` |
+| `getPublicSuffix` | ~`1,130,000` |
+| `getDomain`       | ~`1,000,000` |
+| `getSubdomain`    | ~`1,000,000` |
+| `parse`           | ~`850,000`   |
+
+
+## For random URLs
+
+| Methods           | ops/sec       |
+| ---               | ---           |
+| `isValid`         | ~`25,400,000` |
+| `extractHostname` | ~`400,000`    |
+| `tldExists`       | ~`310,000`    |
+| `getPublicSuffix` | ~`240,000`    |
+| `getDomain`       | ~`240,000`    |
+| `getSubdomain`    | ~`240,000`    |
+| `parse`           | ~`230,000`    |
+
 
 You can measure the performance of `tld.js` on your hardware by running the following command:
 
 ```bash
-npx tldjs -c './bin/benchmark.js'
+npm run benchmark
 ```
+
+If this is not fast enough for your use-case, keep in mind that you can
+provide your own `extractHostname` function (which is the bottle-neck in
+this benchmark) to `tld.js`.
 
 # License
 

--- a/bin/benchmark.js
+++ b/bin/benchmark.js
@@ -6,7 +6,7 @@ var tld = require('../index.js');
 var Benchmark = require('benchmark');
 
 
-var DOMAINS = [
+var HOSTNAMES = [
   // No public suffix
   'example.foo.edu.au', // null
   'example.foo.edu.sh', // null
@@ -30,7 +30,10 @@ var DOMAINS = [
   'example.www.ck', // !www.ck
   'foo.bar.baz.city.yokohama.jp', // !city.yokohama.jp
   'example.city.kobe.jp', // !city.kobe.jp
+];
 
+
+var URLS = [
   // IDN labels
   'example.北海道.jp', // 北海道.jp
   'example.和歌山.jp', // 和歌山.jp
@@ -44,60 +47,83 @@ var DOMAINS = [
   'FOO.bar.BAZ.ortsinfo.AT', // null
 
   // Full URLs
-  // '2001:0DB8:0100:F101:0210:A4FF:FEE3:9566',
-  // 'http://user:pass@www.examplegoogle.com:21/blah#baz',
-  // 'http://iris.test.ing/&#x1E0B;&#x0323;/?&#x1E0B;&#x0323;#&#x1E0B;&#x0323;',
-  // 'http://0000000000000300.0xffffffffFFFFFFFF.3022415481470977',
+  '2001:0DB8:0100:F101:0210:A4FF:FEE3:9566',
+  'http://user:pass@www.examplegoogle.com:21/blah#baz',
+  'http://iris.test.ing/&#x1E0B;&#x0323;/?&#x1E0B;&#x0323;#&#x1E0B;&#x0323;',
+  'http://0000000000000300.0xffffffffFFFFFFFF.3022415481470977',
+  'http://192.168.0.1/',
+  'http://%30%78%63%30%2e%30%32%35%30.01%2e',
+  'http://user:pass@[::1]/segment/index.html?query#frag',
+  'https://[::1]',
 ];
 
 
-// TODO - Compare to other libraries
-function main() {
+function bench(values) {
   console.log(
     'While interpreting the results, keep in mind that each "op" reported' +
-    ' by the benchmark is processing ' + DOMAINS.length + ' domains'
+    ' by the benchmark is processing ' + values.length + ' domains'
   );
 
   new Benchmark.Suite()
+    .add('tldjs#isIp', () => {
+      for (var i = 0; i < values.length; i += 1) {
+        tld.isIp(values[i]);
+      }
+    })
     .add('tldjs#isValid', () => {
-      for (var i = 0; i < DOMAINS.length; i += 1) {
-        tld.isValid(DOMAINS[i]);
+      for (var i = 0; i < values.length; i += 1) {
+        tld.isValid(values[i]);
       }
     })
     .add('tldjs#extractHostname', () => {
-      for (var i = 0; i < DOMAINS.length; i += 1) {
-        tld.extractHostname(DOMAINS[i]);
+      for (var i = 0; i < values.length; i += 1) {
+        tld.extractHostname(values[i]);
       }
     })
     .add('tldjs#tldExists', () => {
-      for (var i = 0; i < DOMAINS.length; i += 1) {
-        tld.tldExists(DOMAINS[i]);
+      for (var i = 0; i < values.length; i += 1) {
+        tld.tldExists(values[i]);
       }
     })
     .add('tldjs#getPublicSuffix', () => {
-      for (var i = 0; i < DOMAINS.length; i += 1) {
-        tld.getPublicSuffix(DOMAINS[i]);
+      for (var i = 0; i < values.length; i += 1) {
+        tld.getPublicSuffix(values[i]);
       }
     })
     .add('tldjs#getDomain', () => {
-      for (var i = 0; i < DOMAINS.length; i += 1) {
-        tld.getDomain(DOMAINS[i]);
+      for (var i = 0; i < values.length; i += 1) {
+        tld.getDomain(values[i]);
       }
     })
     .add('tldjs#getSubdomain', () => {
-      for (var i = 0; i < DOMAINS.length; i += 1) {
-        tld.getSubdomain(DOMAINS[i]);
+      for (var i = 0; i < values.length; i += 1) {
+        tld.getSubdomain(values[i]);
       }
     })
     .add('tldjs#parse', () => {
-      for (var i = 0; i < DOMAINS.length; i += 1) {
-        tld.parse(DOMAINS[i]);
+      for (var i = 0; i < values.length; i += 1) {
+        tld.parse(values[i]);
       }
     })
     .on('cycle', function (event) {
       console.log(String(event.target));
     })
     .run();
+}
+
+
+// TODO - Compare to other libraries
+function main() {
+  console.log('>>> -------------------- <<<');
+  console.log('>>> Only valid hostnames <<<');
+  console.log('>>> -------------------- <<<');
+  bench(HOSTNAMES);
+
+  console.log();
+  console.log('>>> ----------- <<<');
+  console.log('>>> Random URLs <<<');
+  console.log('>>> ----------- <<<');
+  bench(URLS);
 }
 
 

--- a/index.js
+++ b/index.js
@@ -99,7 +99,6 @@ function factory(options) {
 
   return {
     extractHostname: _extractHostname,
-    isIp: isIp,
     isValid: isValid,
     parse: parse,
     tldExists: function (url) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 // Load rules
 var Trie = require('./lib/suffix-trie.js');
 var allRules = Trie.fromJson(require('./rules.json'));
@@ -10,6 +11,7 @@ var getDomain = require('./lib/domain.js');
 var getPublicSuffix = require('./lib/public-suffix.js');
 var getSubdomain = require('./lib/subdomain.js');
 var isValid = require('./lib/is-valid.js');
+var isIp = require('./lib/is-ip.js');
 var tldExists = require('./lib/tld-exists.js');
 
 
@@ -50,11 +52,25 @@ function factory(options) {
     var result = {
       hostname: _extractHostname(url),
       isValid: null,
-      tldExists: null,
+      isIp: null,
+      tldExists: false,
       publicSuffix: null,
       domain: null,
       subdomain: null,
     };
+
+    if (result.hostname === null) {
+      result.isIp = false;
+      result.isValid = false;
+      return result;
+    }
+
+    // Check if `hostname` is a valid ip address
+    result.isIp = isIp(result.hostname);
+    if (result.isIp) {
+      result.isValid = true;
+      return result;
+    }
 
     // Check if `hostname` is valid
     result.isValid = isValid(result.hostname);
@@ -83,6 +99,7 @@ function factory(options) {
 
   return {
     extractHostname: _extractHostname,
+    isIp: isIp,
     isValid: isValid,
     parse: parse,
     tldExists: function (url) {

--- a/lib/clean-host.js
+++ b/lib/clean-host.js
@@ -18,7 +18,7 @@ var isValid = require('./is-valid.js');
 
 // scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
 var hasPrefixRE = /^(([a-z][a-z0-9+.-]*)?:)?\/\//;
-var invalidHostnameChars = /[^A-Za-z0-9.-]/;
+
 
 // @see https://github.com/oncletom/tld.js/issues/95
 function rtrim(value) {
@@ -28,21 +28,64 @@ function rtrim(value) {
   return value;
 }
 
+
+function checkTrimmingNeeded(value) {
+  return (
+    value.length > 0 && (
+      value.charCodeAt(0) <= 32 ||
+      value.charCodeAt(value.length - 1) <= 32
+    )
+  );
+}
+
+
+function checkLowerCaseNeeded(value) {
+  for (var i = 0; i < value.length; i += 1) {
+    var code = value.charCodeAt(i);
+    if (code >= 65 && code <= 90) { // [A-Z]
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
 module.exports = function extractHostname(value) {
+  // First check if `value` is already a valid hostname.
   if (isValid(value)) {
     return rtrim(value);
   }
 
-  var url = ('' + value).toLowerCase().trim();
+  var url = value;
 
-  if (isValid(url)) {
+  if (typeof url !== 'string') {
+    url = '' + url;
+  }
+
+  var needsTrimming = checkTrimmingNeeded(url);
+  if (needsTrimming) {
+    url = url.trim();
+  }
+
+  var needsLowerCase = checkLowerCaseNeeded(url);
+  if (needsLowerCase) {
+    url = url.toLowerCase();
+  }
+
+  // Try again after `url` has been transformed to lowercase and trimmed.
+  if ((needsLowerCase || needsTrimming) && isValid(url)) {
     return rtrim(url);
   }
 
   // Proceed with heavier url parsing to extract the hostname.
-  var parts = URL.parse(hasPrefixRE.test(url) ? url : '//' + url, null, true);
+  if (!hasPrefixRE.test(url)) {
+    url = '//' + url;
+  }
 
-  if (parts.hostname && !invalidHostnameChars.test(parts.hostname)) {
+  var parts = URL.parse(url, null, true);
+
+  if (parts.hostname) {
     return rtrim(parts.hostname);
   }
 

--- a/lib/clean-host.js
+++ b/lib/clean-host.js
@@ -20,8 +20,12 @@ var isValid = require('./is-valid.js');
 var hasPrefixRE = /^(([a-z][a-z0-9+.-]*)?:)?\/\//;
 
 
-// @see https://github.com/oncletom/tld.js/issues/95
-function rtrim(value) {
+/**
+ * @see https://github.com/oncletom/tld.js/issues/95
+ *
+ * @param {string} value
+ */
+function trimTrailingDots(value) {
   if (value[value.length - 1] === '.') {
     return value.substr(0, value.length - 1);
   }
@@ -29,6 +33,11 @@ function rtrim(value) {
 }
 
 
+/**
+ * Fast check to avoid calling `trim` when not needed.
+ *
+ * @param {string} value
+ */
 function checkTrimmingNeeded(value) {
   return (
     value.length > 0 && (
@@ -39,6 +48,11 @@ function checkTrimmingNeeded(value) {
 }
 
 
+/**
+ * Fast check to avoid calling `toLowerCase` when not needed.
+ *
+ * @param {string} value
+ */
 function checkLowerCaseNeeded(value) {
   for (var i = 0; i < value.length; i += 1) {
     var code = value.charCodeAt(i);
@@ -54,7 +68,7 @@ function checkLowerCaseNeeded(value) {
 module.exports = function extractHostname(value) {
   // First check if `value` is already a valid hostname.
   if (isValid(value)) {
-    return rtrim(value);
+    return trimTrailingDots(value);
   }
 
   var url = value;
@@ -75,7 +89,7 @@ module.exports = function extractHostname(value) {
 
   // Try again after `url` has been transformed to lowercase and trimmed.
   if ((needsLowerCase || needsTrimming) && isValid(url)) {
-    return rtrim(url);
+    return trimTrailingDots(url);
   }
 
   // Proceed with heavier url parsing to extract the hostname.
@@ -86,7 +100,7 @@ module.exports = function extractHostname(value) {
   var parts = URL.parse(url, null, true);
 
   if (parts.hostname) {
-    return rtrim(parts.hostname);
+    return trimTrailingDots(parts.hostname);
   }
 
   return null;

--- a/lib/is-ip.js
+++ b/lib/is-ip.js
@@ -2,6 +2,9 @@
 
 
 /**
+ * Check if a hostname is an IP. You should be aware that this only works
+ * because `hostname` is already garanteed to be a valid hostname!
+ *
  * @param {string} hostname
  * @return {boolean}
  */
@@ -29,6 +32,8 @@ function isProbablyIpv4(hostname) {
 
 
 /**
+ * Similar to isProbablyIpv4.
+ *
  * @param {string} hostname
  * @return {boolean}
  */
@@ -53,7 +58,9 @@ function isProbablyIpv6(hostname) {
 
 
 /**
- * Check if `hostname` is a valid ip addr (either ipv6 or ipv4).
+ * Check if `hostname` is *probably* a valid ip addr (either ipv6 or ipv4).
+ * This *will not* work on any string. We need `hostname` to be a valid
+ * hostname.
  *
  * @param {string} hostname
  * @return {boolean}

--- a/lib/is-ip.js
+++ b/lib/is-ip.js
@@ -1,0 +1,71 @@
+'use strict';
+
+
+/**
+ * @param {string} hostname
+ * @return {boolean}
+ */
+function isProbablyIpv4(hostname) {
+  var numberOfDots = 0;
+
+  for (var i = 0; i < hostname.length; i += 1) {
+    var code = hostname.charCodeAt(i);
+
+    if (code === 46) { // '.'
+      numberOfDots += 1;
+    } else if (code < 48 || code > 57) {
+      // 48 => '0'
+      // 57 => '9'
+      return false;
+    }
+  }
+
+  return (
+    numberOfDots === 3  &&
+    hostname[0] !== '.' &&
+    hostname[hostname.length - 1] !== '.'
+  );
+}
+
+
+/**
+ * @param {string} hostname
+ * @return {boolean}
+ */
+function isProbablyIpv6(hostname) {
+  var hasColon = false;
+
+  for (var i = 0; i < hostname.length; i += 1) {
+    var code = hostname.charCodeAt(i);
+
+    if (code === 58) { // ':'
+      hasColon = true;
+    } else if (!(
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 97 && code <= 102)   // a-f
+    )) {
+      return false;
+    }
+  }
+
+  return hasColon;
+}
+
+
+/**
+ * Check if `hostname` is a valid ip addr (either ipv6 or ipv4).
+ *
+ * @param {string} hostname
+ * @return {boolean}
+ */
+module.exports = function isIp(hostname) {
+  if (typeof hostname !== 'string') {
+    return false;
+  }
+
+  if (hostname.length === 0) {
+    return false;
+  }
+
+  return (isProbablyIpv6(hostname) || isProbablyIpv4(hostname));
+};

--- a/lib/is-valid.js
+++ b/lib/is-valid.js
@@ -28,8 +28,8 @@ function isAlpha(code) {
 
 
 /**
- * Check if a hostname string is valid (according to RFC
- * It's usually a preliminary check before trying to use getDomain or anything else
+ * Check if a hostname string is valid (according to RFC). It's usually a
+ * preliminary check before trying to use getDomain or anything else.
  *
  * Beware: it does not check if the TLD exists.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,22 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
+      "dev": true
+    },
+    "JSONStream": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+      "integrity": "sha1-c0KQ5BUR7qfCz+FR+/mlY6l7l4Y=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
+      }
+    },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -106,12 +122,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
       "dev": true
     },
     "base64-js": {
@@ -227,8 +237,8 @@
       "integrity": "sha1-XRxSf1bFgmd0EcTbKhKGSP9r8VA=",
       "dev": true,
       "requires": {
-        "combine-source-map": "0.3.0",
         "JSONStream": "0.6.4",
+        "combine-source-map": "0.3.0",
         "through": "2.3.8"
       },
       "dependencies": {
@@ -281,6 +291,7 @@
       "integrity": "sha1-LC5Kfy9AgXjnjCI7W1ezfCGFrY4=",
       "dev": true,
       "requires": {
+        "JSONStream": "0.7.4",
         "assert": "1.1.2",
         "browser-pack": "2.0.1",
         "browser-resolve": "1.2.4",
@@ -304,7 +315,6 @@
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
         "insert-module-globals": "6.0.0",
-        "JSONStream": "0.7.4",
         "module-deps": "2.0.6",
         "os-browserify": "0.1.2",
         "parents": "0.0.3",
@@ -1390,8 +1400,8 @@
       "integrity": "sha1-7orrne4WgZ4zqhRYilWIJK8MFdw=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.4.10",
         "JSONStream": "0.7.4",
+        "concat-stream": "1.4.10",
         "lexical-scope": "1.1.1",
         "process": "0.6.0",
         "through": "2.3.8",
@@ -1555,16 +1565,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
       "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
-      "integrity": "sha1-c0KQ5BUR7qfCz+FR+/mlY6l7l4Y=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1782,12 +1782,12 @@
       "integrity": "sha1-uZkyHHOsM1gPAHEsDzB1/cpCVj8=",
       "dev": true,
       "requires": {
+        "JSONStream": "0.7.4",
         "browser-resolve": "1.2.4",
         "concat-stream": "1.4.10",
         "detective": "3.1.0",
         "duplexer2": "0.0.2",
         "inherits": "2.0.3",
-        "JSONStream": "0.7.4",
         "minimist": "0.0.10",
         "parents": "0.0.2",
         "readable-stream": "1.0.34",

--- a/test/tld.js
+++ b/test/tld.js
@@ -90,6 +90,31 @@ describe('tld.js', function () {
     });
   });
 
+  describe('isIp method', function () {
+    it('should return false on incorrect inputs', function () {
+      expect(tld.isIp('')).to.be(false);
+      expect(tld.isIp(null)).to.be(false);
+      expect(tld.isIp(undefined)).to.be(false);
+      expect(tld.isIp({})).to.be(false);
+    });
+
+    it('should return true on valid ip addresses', function () {
+      expect(tld.isIp('::1')).to.be(true);
+      expect(tld.isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).to.be(true);
+      expect(tld.isIp('192.168.0.1')).to.be(true);
+    });
+
+    it('should return false on invalid ip addresses', function () {
+      expect(tld.isIp('::1-')).to.be(false);
+      expect(tld.isIp('[::1]')).to.be(false);
+      expect(tld.isIp('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]')).to.be(false);
+      expect(tld.isIp('192.168.0.1.')).to.be(false);
+      expect(tld.isIp('192.168.0')).to.be(false);
+      expect(tld.isIp('192.168.0.')).to.be(false);
+      expect(tld.isIp('192.16-8.0.1')).to.be(false);
+    });
+  });
+
   describe('getDomain method', function () {
     it('should return the expected domain from a simple string', function () {
       expect(tld.getDomain('google.com')).to.equal('google.com');
@@ -346,6 +371,71 @@ describe('tld.js', function () {
     //@see https://github.com/oncletom/tld.js/issues/95
     it('should ignore the trailing dot in a domain', function () {
       expect(tld.getSubdomain('random.fr.google.co.uk.')).to.equal('random.fr');
+    });
+  });
+
+  describe('#parse', function () {
+    it('should handle ipv6 addresses properly', function () {
+      expect(tld.parse('http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]')).to.eql({
+        hostname: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        isValid: true,
+        isIp: true,
+        tldExists: false,
+        publicSuffix: null,
+        domain: null,
+        subdomain: null
+      });
+      expect(tld.parse('http://user:pass@[::1]/segment/index.html?query#frag')).to.eql({
+        hostname: '::1',
+        isValid: true,
+        isIp: true,
+        tldExists: false,
+        publicSuffix: null,
+        domain: null,
+        subdomain: null
+      });
+      expect(tld.parse('https://[::1]')).to.eql({
+        hostname: '::1',
+        isValid: true,
+        isIp: true,
+        tldExists: false,
+        publicSuffix: null,
+        domain: null,
+        subdomain: null
+      });
+      expect(tld.parse('http://[1080::8:800:200C:417A]/foo')).to.eql({
+        hostname: '1080::8:800:200c:417a',
+        isValid: true,
+        isIp: true,
+        tldExists: false,
+        publicSuffix: null,
+        domain: null,
+        subdomain: null
+      });
+    });
+
+
+    it('should handle ipv4 addresses properly', function () {
+      expect(tld.parse('http://192.168.0.1/')).to.eql({
+        hostname: '192.168.0.1',
+        isValid: true,
+        isIp: true,
+        tldExists: false,
+        publicSuffix: null,
+        domain: null,
+        subdomain: null,
+      });
+
+      // `url.parse` currently does not support decoding urls (whatwg-url does)
+      // expect(tld.parse('http://%30%78%63%30%2e%30%32%35%30.01%2e')).to.eql({
+      //   hostname: '192.168.0.1',
+      //   isValid: true,
+      //   isIp: true,
+      //   tldExists: false,
+      //   publicSuffix: null,
+      //   domain: null,
+      //   subdomain: null,
+      // });
     });
   });
 

--- a/test/tld.js
+++ b/test/tld.js
@@ -3,6 +3,10 @@
 /* global suite, test */
 
 var tld = require('../index.js');
+// `isIp` is not exposed as part of the public API because it only works on
+// valid hostname. Hence, we only use it internally.
+
+var isIp = require('../lib/is-ip.js');
 var parser = require('../lib/parsers/publicsuffix-org.js');
 var expect = require('expect.js');
 
@@ -92,26 +96,26 @@ describe('tld.js', function () {
 
   describe('isIp method', function () {
     it('should return false on incorrect inputs', function () {
-      expect(tld.isIp('')).to.be(false);
-      expect(tld.isIp(null)).to.be(false);
-      expect(tld.isIp(undefined)).to.be(false);
-      expect(tld.isIp({})).to.be(false);
+      expect(isIp('')).to.be(false);
+      expect(isIp(null)).to.be(false);
+      expect(isIp(undefined)).to.be(false);
+      expect(isIp({})).to.be(false);
     });
 
     it('should return true on valid ip addresses', function () {
-      expect(tld.isIp('::1')).to.be(true);
-      expect(tld.isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).to.be(true);
-      expect(tld.isIp('192.168.0.1')).to.be(true);
+      expect(isIp('::1')).to.be(true);
+      expect(isIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).to.be(true);
+      expect(isIp('192.168.0.1')).to.be(true);
     });
 
     it('should return false on invalid ip addresses', function () {
-      expect(tld.isIp('::1-')).to.be(false);
-      expect(tld.isIp('[::1]')).to.be(false);
-      expect(tld.isIp('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]')).to.be(false);
-      expect(tld.isIp('192.168.0.1.')).to.be(false);
-      expect(tld.isIp('192.168.0')).to.be(false);
-      expect(tld.isIp('192.168.0.')).to.be(false);
-      expect(tld.isIp('192.16-8.0.1')).to.be(false);
+      expect(isIp('::1-')).to.be(false);
+      expect(isIp('[::1]')).to.be(false);
+      expect(isIp('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]')).to.be(false);
+      expect(isIp('192.168.0.1.')).to.be(false);
+      expect(isIp('192.168.0')).to.be(false);
+      expect(isIp('192.168.0.')).to.be(false);
+      expect(isIp('192.16-8.0.1')).to.be(false);
     });
   });
 


### PR DESCRIPTION
This PR addresses #104. Changes:

- Introduce a fast ip validation to check if a `hostname` is also an IP, and return consistent results.
- Extend `benchmark.js` to show performance when a *valid hostname* is directly given as input (no URL parsing necessary) vs. when a *URL* is given (parsing necessary).

Here is a more detailed view of the current performance:

```
>>> -------------------- <<<
>>> Only valid hostnames <<<
>>> -------------------- <<<
While interpreting the results, keep in mind that each "op" reported by the benchmark is processing 16 domains
tldjs#isIp x 4,543,750 ops/sec ±0.97% (91 runs sampled)
tldjs#isValid x 528,309 ops/sec ±0.48% (95 runs sampled)
tldjs#extractHostname x 485,646 ops/sec ±1.42% (93 runs sampled)
tldjs#tldExists x 125,752 ops/sec ±0.81% (90 runs sampled)
tldjs#getPublicSuffix x 65,652 ops/sec ±1.25% (90 runs sampled)
tldjs#getDomain x 62,128 ops/sec ±0.56% (95 runs sampled)
tldjs#getSubdomain x 58,663 ops/sec ±0.90% (93 runs sampled)
tldjs#parse x 49,101 ops/sec ±0.96% (92 runs sampled)

>>> ----------- <<<
>>> Random URLs <<<
>>> ----------- <<<
While interpreting the results, keep in mind that each "op" reported by the benchmark is processing 16 domains
tldjs#isIp x 4,270,354 ops/sec ±1.30% (87 runs sampled)
tldjs#isValid x 1,389,816 ops/sec ±0.70% (92 runs sampled)
tldjs#extractHostname x 23,037 ops/sec ±1.26% (86 runs sampled)
tldjs#tldExists x 13,854 ops/sec ±0.88% (94 runs sampled)
tldjs#getPublicSuffix x 10,905 ops/sec ±1.00% (96 runs sampled)
tldjs#getDomain x 11,018 ops/sec ±0.58% (92 runs sampled)
tldjs#getSubdomain x 11,081 ops/sec ±1.08% (96 runs sampled)
tldjs#parse x 10,665 ops/sec ±0.58% (95 runs sampled)
```