### PR TITLE
Publish bundles to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "jshint --config .jshintrc lib/**/*.js",
     "postinstall": "node ./bin/postinstall.js",
     "posttest": "npm run lint && npm run test-browser",
+    "prepack": "npm run build && npm run build-min",
     "prepublish": "npm run update",
     "test": "nyc mocha -R dot -r env-test",
     "test-browser": "testling",


### PR DESCRIPTION
It is a nice practice to publish build artifacts directly to npm, so consuming projects don't have to browserify themselves.
Additionally, user can verify if the version of library in use is in fact the one being published (and not being modified / forged).

Would be great to see a release containing bundles anytime soon :-)