### PR TITLE
Fix documentation about isValid and introduce isValidHostname for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,20 +151,20 @@ getPublicSuffix('s3.amazonaws.com'); // returns `s3.amazonaws.com`
 getPublicSuffix('tld.is.unknown');   // returns `unknown`
 ```
 
-### isValid()
+### isValidHostname()
 
-Checks the validity of a given string — parseable with [`require('url').parse`][].
+Checks if the given string is a valid hostname according to [RFC 1035](https://tools.ietf.org/html/rfc1035).
 It does not check if the TLD is _well-known_.
 
 ```javascript
-const { isValid } = tldjs;
+const { isValidHostname } = tldjs;
 
-isValid('google.com');      // returns `true`
-isValid('.google.com');     // returns `false`
-isValid('my.fake.domain');  // returns `true`
-isValid('localhost');       // returns `false`
-isValid('https://user:password@example.co.uk:8080/some/path?and&query#hash'); // returns `true`
-isValid('192.168.0.0')      // returns `true`
+isValidHostname('google.com');      // returns `true`
+isValidHostname('.google.com');     // returns `false`
+isValidHostname('my.fake.domain');  // returns `true`
+isValidHostname('localhost');       // returns `false`
+isValidHostname('https://user:password@example.co.uk:8080/some/path?and&query#hash'); // returns `false`
+isValidHostname('192.168.0.0')      // returns `true`
 ```
 
 # Troubleshooting
@@ -231,7 +231,7 @@ On an Intel i7-6600U (2,60-3,40 GHz):
 
 | Methods           | ops/sec      |
 | ---               | ---          |
-| `isValid`         | ~`8,700,000` |
+| `isValidHostname` | ~`8,700,000` |
 | `extractHostname` | ~`8,100,000` |
 | `tldExists`       | ~`2,000,000` |
 | `getPublicSuffix` | ~`1,130,000` |
@@ -244,7 +244,7 @@ On an Intel i7-6600U (2,60-3,40 GHz):
 
 | Methods           | ops/sec       |
 | ---               | ---           |
-| `isValid`         | ~`25,400,000` |
+| `isValidHostname` | ~`25,400,000` |
 | `extractHostname` | ~`400,000`    |
 | `tldExists`       | ~`310,000`    |
 | `getPublicSuffix` | ~`240,000`    |

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var extractHostname = require('./lib/clean-host.js');
 var getDomain = require('./lib/domain.js');
 var getPublicSuffix = require('./lib/public-suffix.js');
 var getSubdomain = require('./lib/subdomain.js');
-var isValid = require('./lib/is-valid.js');
+var isValidHostname = require('./lib/is-valid.js');
 var isIp = require('./lib/is-ip.js');
 var tldExists = require('./lib/tld-exists.js');
 
@@ -73,22 +73,22 @@ function factory(options) {
     }
 
     // Check if `hostname` is valid
-    result.isValid = isValid(result.hostname);
-    if (result.isValid === false) return result;
+    result.isValid = isValidHostname(result.hostname);
+    if (result.isValid === false) { return result; }
 
     // Check if tld exists
     if (step === ALL || step === TLD_EXISTS) {
       result.tldExists = tldExists(rules, result.hostname);
     }
-    if (step === TLD_EXISTS) return result;
+    if (step === TLD_EXISTS) { return result; }
 
     // Extract public suffix
     result.publicSuffix = getPublicSuffix(rules, result.hostname);
-    if (step === PUBLIC_SUFFIX) return result;
+    if (step === PUBLIC_SUFFIX) { return result; }
 
     // Extract domain
     result.domain = getDomain(validHosts, result.publicSuffix, result.hostname);
-    if (step === DOMAIN) return result;
+    if (step === DOMAIN) { return result; }
 
     // Extract subdomain
     result.subdomain = getSubdomain(result.hostname, result.domain);
@@ -99,7 +99,8 @@ function factory(options) {
 
   return {
     extractHostname: _extractHostname,
-    isValid: isValid,
+    isValidHostname: isValidHostname,
+    isValid: isValidHostname,
     parse: parse,
     tldExists: function (url) {
       return parse(url, TLD_EXISTS).tldExists;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 // Load rules
 var Trie = require('./lib/suffix-trie.js');
 var allRules = Trie.fromJson(require('./rules.json'));
@@ -100,7 +99,11 @@ function factory(options) {
   return {
     extractHostname: _extractHostname,
     isValidHostname: isValidHostname,
-    isValid: isValidHostname,
+    isValid: function (hostname) {
+      // eslint-disable-next-line
+      console.error('DeprecationWarning: "isValid" is deprecated, please use "isValidHostname" instead.');
+      return isValidHostname(hostname);
+    },
     parse: parse,
     tldExists: function (url) {
       return parse(url, TLD_EXISTS).tldExists;


### PR DESCRIPTION
This aims at addressing: #112 

- Fix the documentation about `isValid`.
- Introduce `isValidHostname` to make the intent clear.
- Leave `isValid` as part of the API for backward compatibility.