### PR TITLE
Introduce 'lenient' mode for hostname validation.

### DIFF
--- a/lib/is-valid.js
+++ b/lib/is-valid.js
@@ -37,7 +37,12 @@ function isAlpha(code) {
  * @param {string} hostname
  * @return {boolean}
  */
-module.exports = function isValid(hostname) {
+module.exports = function isValid(hostname, _extraValidCode) {
+  var extraValidCode = function (code) { return code === 45; };
+  if (_extraValidCode !== undefined) {
+    extraValidCode = _extraValidCode;
+  }
+
   if (typeof hostname !== 'string') {
     return false;
   }
@@ -72,13 +77,13 @@ module.exports = function isValid(hostname) {
         // Check that previous character was not already a '.'
         lastCharCode === 46 ||
         // Check that the previous label does not end with a '-'
-        lastCharCode === 45
+        extraValidCode(lastCharCode)
       ) {
         return false;
       }
 
       lastDotIndex = i;
-    } else if (!(isAlpha(code) || isDigit(code) || code === 45)) {
+    } else if (!(isAlpha(code) || isDigit(code) || extraValidCode(code))) {
       // Check if there is a forbidden character in the label: [^a-zA-Z0-9-]
       return false;
     }

--- a/test/tld.js
+++ b/test/tld.js
@@ -70,6 +70,9 @@ describe('tld.js', function () {
       expect(tld.isValid('example.' + repeat('a', 63) + '.')).to.be(true);
       expect(tld.isValid('example.' + repeat('a', 63))).to.be(true);
 
+      // Rejects domains with '_'
+      expect(tld.isValid('foo.bar_baz.com')).to.be(false);
+
       //@see https://github.com/oncletom/tld.js/issues/95
       expect(tld.isValid('miam.miam.google.com.')).to.be(true);
 
@@ -91,6 +94,12 @@ describe('tld.js', function () {
       expect(tld.isValid('.localhost')).to.be(false);
       expect(tld.isValid('.google.com')).to.be(false);
       expect(tld.isValid('.com')).to.be(false);
+    });
+
+    it('should accept extra code points in domain with lenien mode', function () {
+      // @see https://github.com/oncletom/tld.js/pull/122
+      var customTld = tld.fromUserSettings({ lenientHostnameValidation: true });
+      expect(customTld.isValid('foo.bar_baz.com')).to.be(true);
     });
   });
 


### PR DESCRIPTION
This PR should address the long-standing #73 issue. It is now possible to enable a more permissive hostname validation using the `lenientHostnameValidation` option:

```js
> var tldjs = require('tldjs');
> tldjs.isValid('foo.bar_baz.com')
false
> var customTld = tldjs.fromUserSettings({ lenientHostnameValidation: true });
> customTld.isValid('foo.bar_baz.com')
true
```