### PR TITLE
Introduce two new options to enabled/disabled the Private/ICANN domains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,37 @@ isValidHostname('192.168.0.0')      // returns `true`
 
 # Troubleshooting
 
+## Ignoring Private domain section of public suffix list
+
+Because `tld.js` relies on public suffix list to parse URLs and hostnames, you
+might encounter counter-intuitive results from time to time. Most of these
+results stems from the fact that public suffix list contains two sections: ICANN
+domains and Private domains. The *ICANN* section defines what you would expect to
+see as top-level domains most of the time: `.com`, `.net`, `co.uk`, etc. On the
+other hand, the *Private* section contains rules such as: `global.prod.fastly.net`
+or `s3.amazonaws.com`. This means that these values can appear as `publicSuffix`.
+
+Fortunately, you can ask `tld.js` to ignore the *Private* section completely:
+```js
+const tldjs = require('tldjs');
+
+tldjs.getDomain('www.s3.amazonaws.com');  // returns 'www.s3.amazonaws.com'
+tldjs.getDomain('https://global.prod.fastly.net'); // returns null
+
+const myTldjs = tldjs.fromUserSettings({
+  allowPrivate: false,
+});
+
+myTldjs.getDomain('www.s3.amazonaws.com');  // returns 'amazonaws.com'
+myTldjs.getDomain('https://global.prod.fastly.net'); // returns 'fastly.net'
+```
+
 ## Retrieving subdomain of `localhost` and custom hostnames
 
 `tld.js` methods `getDomain` and `getSubdomain` are designed to **work only with *known and valid* TLDs**.
 This way, you can trust what a domain is.
 
-`localhost` is a valid hostname but not a TLD. Although you can instanciate your own flavour of `tld.js` with *additional valid hosts*:
+`localhost` is a valid hostname but not a TLD. Although you can instantiate your own flavour of `tld.js` with *additional valid hosts*:
 
 ```js
 const tldjs = require('tldjs');
@@ -225,28 +250,28 @@ use-case. Because the library tried to be smart, the speed can be drastically
 different depending on the input (it will be faster if you provide an already
 cleaned hostname, compared to a random URL).
 
-On an Intel i7-6600U (2,60-3,40 GHz):
+On an Intel i7-6600U (2,60-3,40 GHz) using Node.js `v9.8.0`:
 
 ## For already cleaned hostnames
 
-| Methods           | ops/sec      |
-| ---               | ---          |
-| `isValidHostname` | ~`8,700,000` |
-| `extractHostname` | ~`8,100,000` |
-| `tldExists`       | ~`2,000,000` |
-| `getPublicSuffix` | ~`1,130,000` |
-| `getDomain`       | ~`1,000,000` |
-| `getSubdomain`    | ~`1,000,000` |
-| `parse`           | ~`850,000`   |
+| Methods           | ops/sec       |
+| ---               | ---           |
+| `isValidHostname` | ~`25,300,000` |
+| `extractHostname` | ~`20,000,000` |
+| `tldExists`       | ~`3,200,000`  |
+| `getPublicSuffix` | ~`1,200,000`  |
+| `getDomain`       | ~`1,100,000`  |
+| `getSubdomain`    | ~`1,100,000`  |
+| `parse`           | ~`870,000`    |
 
 
 ## For random URLs
 
 | Methods           | ops/sec       |
 | ---               | ---           |
-| `isValidHostname` | ~`25,400,000` |
-| `extractHostname` | ~`400,000`    |
-| `tldExists`       | ~`310,000`    |
+| `isValidHostname` | ~`50,000,000` |
+| `extractHostname` | ~`360,000`    |
+| `tldExists`       | ~`300,000`    |
 | `getPublicSuffix` | ~`240,000`    |
 | `getDomain`       | ~`240,000`    |
 | `getSubdomain`    | ~`240,000`    |

--- a/bin/benchmark.js
+++ b/bin/benchmark.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var tld = require('../index.js');
+var isIp = require('../lib/is-ip.js');
 var Benchmark = require('benchmark');
 
 
@@ -67,7 +68,7 @@ function bench(values) {
   new Benchmark.Suite()
     .add('tldjs#isIp', () => {
       for (var i = 0; i < values.length; i += 1) {
-        tld.isIp(values[i]);
+        isIp(values[i]);
       }
     })
     .add('tldjs#isValid', () => {

--- a/index.js
+++ b/index.js
@@ -35,6 +35,17 @@ function factory(options) {
   var validHosts = options.validHosts || [];
   var _extractHostname = options.extractHostname || extractHostname;
 
+  // Customize ICANN/Private domain
+  var allowIcann = true;
+  if (options.allowIcann !== undefined) {
+    allowIcann = options.allowIcann;
+  }
+
+  var allowPrivate = true;
+  if (options.allowPrivate !== undefined) {
+    allowPrivate = options.allowPrivate;
+  }
+
   /**
    * Process a given url and extract all information. This is a higher level API
    * around private functions of `tld.js`. It allows to remove duplication (only
@@ -54,6 +65,8 @@ function factory(options) {
       isIp: null,
       tldExists: false,
       publicSuffix: null,
+      // isIcann: false,
+      // isPrivate: false,
       domain: null,
       subdomain: null,
     };
@@ -82,7 +95,11 @@ function factory(options) {
     if (step === TLD_EXISTS) { return result; }
 
     // Extract public suffix
-    result.publicSuffix = getPublicSuffix(rules, result.hostname);
+    result.publicSuffix = getPublicSuffix(
+      rules,
+      result.hostname,
+      allowIcann,
+      allowPrivate).publicSuffix;
     if (step === PUBLIC_SUFFIX) { return result; }
 
     // Extract domain
@@ -109,7 +126,7 @@ function factory(options) {
       return parse(url, TLD_EXISTS).tldExists;
     },
     getPublicSuffix: function (url) {
-      return parse(url, PUBLIC_SUFFIX).publicSuffix;
+      return parse(url, PUBLIC_SUFFIX, allowIcann, allowPrivate).publicSuffix;
     },
     getDomain: function (url) {
       return parse(url, DOMAIN).domain;

--- a/lib/parsers/publicsuffix-org.js
+++ b/lib/parsers/publicsuffix-org.js
@@ -7,71 +7,60 @@ var PublicSuffixOrgParser = {};
 
 
 /**
- * Filters a commented or empty line
- *
- * @param {string} row
- * @return {string|null}
- */
-function keepOnlyRules(row) {
-  var trimmed = row.trim();
-  if (trimmed.length === 0 || trimmed.indexOf('//') === 0) {
-    return null;
-  }
-
-  // TODO - Ignore leading or trailing dot
-
-  return trimmed;
-}
-
-
-/**
- * Returns a rule based on string analysis
- *
- * @param {string} row
- * @return {object} a public suffix rule
- */
-function domainBuilder(row) {
-  var rule = {
-    exception: false,
-    source: null,
-    parts: null,
-  };
-
-  // Only read line up to the first white-space
-  var spaceIndex = row.indexOf(' ');
-  if (spaceIndex !== -1) {
-    row = row.substr(0, spaceIndex);
-  }
-
-  row = punycode.toASCII(row);
-
-  // Keep track of initial rule
-  rule.source = row;
-
-  // Exception
-  if (row[0] === '!') {
-    row = row.substr(1);
-    rule.exception = true;
-  }
-
-  rule.parts = row.split('.').reverse();
-
-  return rule;
-}
-
-
-/**
  * Parse a one-domain-per-line file
  *
  * @param body {String}
  * @return {Array}
  */
 PublicSuffixOrgParser.parse = function (body) {
-  return new SuffixTrie((body + '')
-    .split('\n')
-    .map(keepOnlyRules)
-    .filter(function (r) { return r !== null; })
-    .map(domainBuilder));
+  var beginPrivateDomains = '// ===BEGIN PRIVATE DOMAINS===';
+  var lines = ('' + body).split('\n');
+
+  var rules = [];
+  var isIcann = true;
+
+  for (var i = 0; i < lines.length; i += 1) {
+    var line = lines[i].trim();
+
+    // Ignore empty lines
+    if (line.length === 0) { continue; }
+
+    // Comment (check for beginning of Private domains section)
+    if (line.startsWith('//')) {
+      if (line.startsWith(beginPrivateDomains)) {
+        isIcann = false;
+      }
+
+      continue;
+    }
+
+    // TODO - Ignore leading or trailing dot
+
+    // Only read line up to the first white-space
+    var spaceIndex = line.indexOf(' ');
+    if (spaceIndex !== -1) {
+      line = line.substr(0, spaceIndex);
+    }
+
+    // Convert to punycode
+    line = punycode.toASCII(line);
+
+    // Check if the rule is an exception
+    var exception = false;
+    if (line[0] === '!') {
+      line = line.substr(1);
+      exception = true;
+    }
+
+    rules.push({
+      isIcann: isIcann,
+      exception: exception,
+      source: lines[i],
+      parts: line.split('.').reverse(),
+    });
+  }
+
+  return new SuffixTrie(rules);
 };
 
 

--- a/lib/public-suffix.js
+++ b/lib/public-suffix.js
@@ -12,17 +12,25 @@ var extractTldFromHost = require('./from-host.js');
  * @param {string} hostname
  * @return {string}
  */
-module.exports = function getPublicSuffix(rules, hostname) {
+module.exports = function getPublicSuffix(rules, hostname, allowIcann, allowPrivate) {
   // First check if `hostname` is already a valid top-level Domain.
   if (rules.hasTld(hostname)) {
-    return hostname;
+    return {
+      publicSuffix: hostname,
+      isIcann: false,
+      isPrivate: false,
+    };
   }
 
-  var candidate = rules.suffixLookup(hostname);
+  var candidate = rules.suffixLookup(hostname, allowIcann, allowPrivate);
   if (candidate === null) {
     // Prevailing rule is '*' so we consider the top-level domain to be the
     // public suffix of `hostname` (e.g.: 'example.org' => 'org').
-    return extractTldFromHost(hostname);
+    return {
+      isIcann: false,
+      isPrivate: false,
+      publicSuffix: extractTldFromHost(hostname),
+    };
   }
 
   return candidate;

--- a/lib/suffix-trie.js
+++ b/lib/suffix-trie.js
@@ -1,23 +1,22 @@
 'use strict';
 
-var VALID_HOSTNAME_VALUE = 0;
+
+// Flags used to know if a rule is ICANN or Private
+var ICANN_HOSTNAME = 1;
+var PRIVATE_HOSTNAME = 2;
 
 
 /**
- * Return min(a, b), handling possible `null` values.
- *
- * @param {number|null} a
- * @param {number|null} b
- * @return {number|null}
+ * Return the lookup object having the longest match, ignoring possible `-1` values.
  */
-function minIndex(a, b) {
-  if (a === null) {
+function longestMatch(a, b) {
+  if (a.index === -1) {
     return b;
-  } else if (b === null) {
+  } else if (b.index === -1) {
     return a;
   }
 
-  return a < b ? a : b;
+  return a.index < b.index ? a : b;
 }
 
 
@@ -43,7 +42,7 @@ function insertInTrie(rule, trie) {
     node = nextNode;
   }
 
-  node.$ = VALID_HOSTNAME_VALUE;
+  node.$ = rule.isIcann ? ICANN_HOSTNAME : PRIVATE_HOSTNAME;
 
   return trie;
 }
@@ -57,19 +56,27 @@ function insertInTrie(rule, trie) {
  * @param {number} index - when to start in `parts` (initially: length - 1)
  * @return {number} size of the suffix found (in number of parts matched)
  */
-function lookupInTrie(parts, trie, index) {
+function lookupInTrie(parts, trie, index, allowedMask) {
   var part;
   var nextNode;
-  var publicSuffixIndex = null;
+  var lookupResult = {
+    index: -1,
+    isIcann: false,
+    isPrivate: false,
+  };
 
   // We have a match!
-  if (trie.$ !== undefined) {
-    publicSuffixIndex = index + 1;
+  if (trie.$ !== undefined && (trie.$ & allowedMask) !== 0) {
+    lookupResult = {
+      index: index + 1,
+      isIcann: trie.$ === ICANN_HOSTNAME,
+      isPrivate: trie.$ === PRIVATE_HOSTNAME,
+    };
   }
 
   // No more `parts` to look for
   if (index === -1) {
-    return publicSuffixIndex;
+    return lookupResult;
   }
 
   part = parts[index];
@@ -77,22 +84,22 @@ function lookupInTrie(parts, trie, index) {
   // Check branch corresponding to next part of hostname
   nextNode = trie[part];
   if (nextNode !== undefined) {
-    publicSuffixIndex = minIndex(
-      publicSuffixIndex,
-      lookupInTrie(parts, nextNode, index - 1)
+    lookupResult = longestMatch(
+      lookupResult,
+      lookupInTrie(parts, nextNode, index - 1, allowedMask)
     );
   }
 
   // Check wildcard branch
   nextNode = trie['*'];
   if (nextNode !== undefined) {
-    publicSuffixIndex = minIndex(
-      publicSuffixIndex,
-      lookupInTrie(parts, nextNode, index - 1)
+    lookupResult = longestMatch(
+      lookupResult,
+      lookupInTrie(parts, nextNode, index - 1, allowedMask)
     );
   }
 
-  return publicSuffixIndex;
+  return lookupResult;
 }
 
 
@@ -146,32 +153,52 @@ SuffixTrie.prototype.hasTld = function (value) {
  * @param {string} hostname
  * @return {string|null} public suffix
  */
-SuffixTrie.prototype.suffixLookup = function (hostname) {
+SuffixTrie.prototype.suffixLookup = function (hostname, allowIcann, allowPrivate) {
   var parts = hostname.split('.');
 
+  var allowedMask = 0;
+
+  // Define set of accepted public suffix (ICANN, PRIVATE)
+  if (allowPrivate === undefined || allowPrivate === true) {
+    allowedMask |= PRIVATE_HOSTNAME;
+  }
+  if (allowIcann === undefined || allowIcann === true) {
+    allowedMask |= ICANN_HOSTNAME;
+  }
+
   // Look for a match in rules
-  var publicSuffixIndex = lookupInTrie(
+  var lookupResult = lookupInTrie(
     parts,
     this.rules,
-    parts.length - 1
+    parts.length - 1,
+    allowedMask
   );
 
-  if (publicSuffixIndex === null) {
+  if (lookupResult.index === -1) {
     return null;
   }
 
   // Look for exceptions
-  var exceptionIndex = lookupInTrie(
+  var exceptionLookupResult = lookupInTrie(
     parts,
     this.exceptions,
-    parts.length - 1
+    parts.length - 1,
+    allowedMask
   );
 
-  if (exceptionIndex !== null) {
-    return parts.slice(exceptionIndex + 1).join('.');
+  if (exceptionLookupResult.index !== -1) {
+    return {
+      isIcann: exceptionLookupResult.isIcann,
+      isPrivate: exceptionLookupResult.isPrivate,
+      publicSuffix: parts.slice(exceptionLookupResult.index + 1).join('.'),
+    };
   }
 
-  return parts.slice(publicSuffixIndex).join('.');
+  return {
+    isIcann: lookupResult.isIcann,
+    isPrivate: lookupResult.isPrivate,
+    publicSuffix: parts.slice(lookupResult.index).join('.'),
+  };
 };
 
 

--- a/test/tld.js
+++ b/test/tld.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-/* global suite, test */
+/* global describe, it, context, before */
 
 var tld = require('../index.js');
 // `isIp` is not exposed as part of the public API because it only works on
@@ -223,7 +223,7 @@ describe('tld.js', function () {
     });
 
     it('should return s3.amazonaws.com if www.s3.amazonaws.com', function () {
-      expect(tld.getPublicSuffix('s3.amazonaws.com')).to.be('s3.amazonaws.com');
+      expect(tld.getPublicSuffix('www.s3.amazonaws.com')).to.be('s3.amazonaws.com');
     });
 
     it('should directly return the suffix if it matches a rule key', function(){
@@ -242,6 +242,44 @@ describe('tld.js', function () {
     // @see https://github.com/oncletom/tld.js/issues/95
     it('should ignore the trailing dot in a domain', function () {
       expect(tld.getPublicSuffix('https://www.google.co.uk./maps')).to.equal('co.uk');
+    });
+
+    describe('ignoring Private domains', function () {
+      var customTld;
+      before(function () {
+        customTld = tld.fromUserSettings({ allowPrivate: false });
+      });
+
+      it('should return com if www.s3.amazonaws.com', function () {
+        expect(customTld.getPublicSuffix('www.s3.amazonaws.com')).to.be('com');
+      });
+
+      it('should return net if global.prod.fastly.net', function () {
+        expect(customTld.getPublicSuffix('https://global.prod.fastly.net')).to.equal('net');
+      });
+
+      it('should return co.uk if google.co.uk', function () {
+        expect(customTld.getPublicSuffix('google.co.uk')).to.be('co.uk');
+      });
+    });
+
+    describe('ignoring ICANN domains', function () {
+      var customTld;
+      before(function () {
+        customTld = tld.fromUserSettings({ allowIcann: false });
+      });
+
+      it('should return s3.amazonaws.com if www.s3.amazonaws.com', function () {
+        expect(customTld.getPublicSuffix('www.s3.amazonaws.com')).to.be('s3.amazonaws.com');
+      });
+
+      it('should return global.prod.fastly.net if global.prod.fastly.net', function () {
+        expect(customTld.getPublicSuffix('https://global.prod.fastly.net')).to.equal('global.prod.fastly.net');
+      });
+
+      it('should return co.uk if google.co.uk', function () {
+        expect(customTld.getPublicSuffix('google.co.uk')).to.be('uk');
+      });
     });
   });
 
@@ -505,37 +543,37 @@ describe('tld.js', function () {
     it('should parse up to the first space', function () {
       var tlds = parser.parse('co.uk .evil');
       expect(tlds.exceptions).to.eql({});
-      expect(tlds.rules).to.eql({ uk: { co: { $: 0 } } });
+      expect(tlds.rules).to.eql({ uk: { co: { $: 1 } } });
     });
 
     it('should parse normal rule', function () {
       var tlds = parser.parse('co.uk');
       expect(tlds.exceptions).to.eql({});
-      expect(tlds.rules).to.eql({ uk: { co: { $: 0 } } });
+      expect(tlds.rules).to.eql({ uk: { co: { $: 1 } } });
     });
 
     it('should parse exception', function () {
       var tlds = parser.parse('!co.uk');
-      expect(tlds.exceptions).to.eql({ uk: { co: { $: 0 } } });
+      expect(tlds.exceptions).to.eql({ uk: { co: { $: 1 } } });
       expect(tlds.rules).to.eql({});
     });
 
     it('should parse wildcard', function () {
       var tlds = parser.parse('*');
       expect(tlds.exceptions).to.eql({});
-      expect(tlds.rules).to.eql({ '*': { $: 0 } });
-      expect(tlds.suffixLookup('foo')).to.equal('foo');
+      expect(tlds.rules).to.eql({ '*': { $: 1 } });
+      expect(tlds.suffixLookup('foo').publicSuffix).to.equal('foo');
 
       tlds = parser.parse('*.uk');
       expect(tlds.exceptions).to.eql({});
-      expect(tlds.rules).to.eql({ uk: { '*': { $: 0 } } });
-      expect(tlds.suffixLookup('bar.uk')).to.equal('bar.uk');
+      expect(tlds.rules).to.eql({ uk: { '*': { $: 1 } } });
+      expect(tlds.suffixLookup('bar.uk').publicSuffix).to.equal('bar.uk');
       expect(tlds.suffixLookup('bar.baz')).to.equal(null);
 
       tlds = parser.parse('foo.*.baz');
       expect(tlds.exceptions).to.eql({});
-      expect(tlds.rules).to.eql({ baz: { '*': { foo: { $: 0 } } } });
-      expect(tlds.suffixLookup('foo.bar.baz')).to.equal('foo.bar.baz');
+      expect(tlds.rules).to.eql({ baz: { '*': { foo: { $: 1 } } } });
+      expect(tlds.suffixLookup('foo.bar.baz').publicSuffix).to.equal('foo.bar.baz');
       expect(tlds.suffixLookup('foo.foo.bar')).to.equal(null);
       expect(tlds.suffixLookup('bar.foo.baz')).to.equal(null);
       expect(tlds.suffixLookup('foo.baz')).to.equal(null);
@@ -543,40 +581,40 @@ describe('tld.js', function () {
 
       tlds = parser.parse('foo.bar.*');
       expect(tlds.exceptions).to.eql({});
-      expect(tlds.rules).to.eql({ '*': { bar: { foo: { $: 0 } } } });
-      expect(tlds.suffixLookup('foo.bar.baz')).to.equal('foo.bar.baz');
+      expect(tlds.rules).to.eql({ '*': { bar: { foo: { $: 1 } } } });
+      expect(tlds.suffixLookup('foo.bar.baz').publicSuffix).to.equal('foo.bar.baz');
       expect(tlds.suffixLookup('foo.foo.bar')).to.equal(null);
 
       tlds = parser.parse('foo.*.*');
       expect(tlds.exceptions).to.eql({});
-      expect(tlds.rules).to.eql({ '*': { '*': { foo: { $: 0 } } } });
-      expect(tlds.suffixLookup('foo.bar.baz')).to.equal('foo.bar.baz');
-      expect(tlds.suffixLookup('foo.foo.bar')).to.equal('foo.foo.bar');
+      expect(tlds.rules).to.eql({ '*': { '*': { foo: { $: 1 } } } });
+      expect(tlds.suffixLookup('foo.bar.baz').publicSuffix).to.equal('foo.bar.baz');
+      expect(tlds.suffixLookup('foo.foo.bar').publicSuffix).to.equal('foo.foo.bar');
       expect(tlds.suffixLookup('baz.foo.bar')).to.equal(null);
 
       tlds = parser.parse('fo.bar.*\nfoo.bar.baz');
       expect(tlds.exceptions).to.eql({});
       expect(tlds.rules).to.eql({
         baz: {
-          bar: { foo: { $: 0 } },
+          bar: { foo: { $: 1 } },
         },
         '*': {
-          bar: { fo: { $: 0 } },
+          bar: { fo: { $: 1 } },
         }
       });
-      expect(tlds.suffixLookup('foo.bar.baz')).to.equal('foo.bar.baz');
+      expect(tlds.suffixLookup('foo.bar.baz').publicSuffix).to.equal('foo.bar.baz');
 
       tlds = parser.parse('bar.*\nfoo.bar.baz');
       expect(tlds.exceptions).to.eql({});
       expect(tlds.rules).to.eql({
         baz: {
-          bar: { foo: { $: 0 } },
+          bar: { foo: { $: 1 } },
         },
         '*': {
-          bar: { $: 0 },
+          bar: { $: 1 },
         }
       });
-      expect(tlds.suffixLookup('foo.bar.baz')).to.equal('foo.bar.baz');
+      expect(tlds.suffixLookup('foo.bar.baz').publicSuffix).to.equal('foo.bar.baz');
     });
 
     it('should insert rules with same TLD', function () {
@@ -584,9 +622,24 @@ describe('tld.js', function () {
       expect(tlds.exceptions).to.eql({});
       expect(tlds.rules).to.eql({
         uk: {
-          ca: { $: 0 },
-          co: { $: 0 }
+          ca: { $: 1 },
+          co: { $: 1 }
         }
+      });
+    });
+
+    it('should make the distinction between Private and ICANN', function () {
+      var tlds = parser.parse([
+        'co.uk',
+        '// comment',
+        '// ===BEGIN PRIVATE DOMAINS===',
+        'ca.ul',
+        '!foo.bar',
+      ].join('\n'));
+      expect(tlds.exceptions).to.eql({ bar: { foo: { $: 2 } } });
+      expect(tlds.rules).to.eql({
+        uk: { co: { $: 1 } },
+        ul: { ca: { $: 2 } },
       });
     });
   });


### PR DESCRIPTION
When given as an option to `fromUserSettings`:
* `allowIcann` set to `false` will ignore the ICANN section of the list.
* `allowPrivate` set to `false` will ignore the PRIVATE section of the list.

This is an attempt to address the recurring issue about non-intuitive results on some domains. In particular, it allows to disable the use of the `PRIVATE` section from public suffix list (You can also disable the use of `ICANN` domains but it's probably less useful).

Instantiate `tld.js` with the custom option:
```js
> const tldjs = require('./index.js')
> const custom = tld.fromUserSettings({ allowPrivate: false })
```

### #120 

```js
> custom.parse('acc1sub1-dot-moisestest.appspot.com')
{ hostname: 'acc1sub1-dot-moisestest.appspot.com',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'com',
  domain: 'appspot.com',
  subdomain: 'acc1sub1-dot-moisestest' }
```

### #117 

```js
> custom.parse('https://github.io')
{ hostname: 'github.io',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'io',
  domain: 'github.io',
  subdomain: '' }
> custom.parse('https://ngrok.io')
{ hostname: 'ngrok.io',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'io',
  domain: 'ngrok.io',
  subdomain: '' }
> custom.parse('https://sandcats.io')
{ hostname: 'sandcats.io',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'io',
  domain: 'sandcats.io',
  subdomain: '' }
```

### #111 

```js
> custom.parse('http://bntp-assets.global.ssl.fastly.net/')
{ hostname: 'bntp-assets.global.ssl.fastly.net',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'net',
  domain: 'fastly.net',
  subdomain: 'bntp-assets.global.ssl' }
> custom.parse('http://cres-wpstatic.freetls.fastly.net/')
{ hostname: 'cres-wpstatic.freetls.fastly.net',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'net',
  domain: 'fastly.net',
  subdomain: 'cres-wpstatic.freetls' }
> custom.parse('http://r3engage-live.global.ssl.fastly.net/')
{ hostname: 'r3engage-live.global.ssl.fastly.net',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'net',
  domain: 'fastly.net',
  subdomain: 'r3engage-live.global.ssl' }
> custom.parse('http://ticket-magic-ember-herokuapp-com.global.ssl.fastly.net/')
{ hostname: 'ticket-magic-ember-herokuapp-com.global.ssl.fastly.net',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'net',
  domain: 'fastly.net',
  subdomain: 'ticket-magic-ember-herokuapp-com.global.ssl' }
```

### #25 

```js
> custom.parse('blogspot.co.uk')
{ hostname: 'blogspot.co.uk',
  isValid: true,
  isIp: false,
  tldExists: true,
  publicSuffix: 'co.uk',
  domain: 'blogspot.co.uk',
  subdomain: '' }
```

So most of the issues are solved at this point. There are a few corner cases not handled by this change, but they could be with a few more options to customize the behavior of `tld.js`. In particular, #78 could benefit from an option to disable the use of *wildcard* rules (such as `*.er` which will consider `google.er` to have public suffix `google.er`).

@oncletom Do you think it could be useful to also add two fields in the resulting object from `parse`: `isIcann` and `isPrivate`. This would allow to know what kind of rule was used to parse a given URL/hostname.

Also, this PR introduces a breaking change in the way the trie is serialized/represented. Instead of having value `0` as leaf values, it now has either `1` (ICANN) or `2` (Private).